### PR TITLE
Use date object for dates across the application

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -10,15 +10,18 @@ def run_all_tests():
     runner = unittest.TextTestRunner()
     runner.run(suite)
 
+
 def parse_flags() -> None:
-    pass #will be implemented later
+    pass  # will be implemented later
+
+
 """
     flags = {
         "-h": "help",
         "-v": "verbose",
     }
 """
-    
+
 
 if __name__ == "__main__":
     print("Running test suite via unittest...")

--- a/src/course.py
+++ b/src/course.py
@@ -43,7 +43,11 @@ class Course:
         self.name: str = name
         self.description: str = description
         self.code: str = code
+        if not isinstance(start_date, date):
+            raise TypeError("Start Date must be a date object")
         self.start_date: date = start_date
+        if not isinstance(end_date, date):
+            raise TypeError("Start Date must be a date object")
         self.end_date: date = end_date
         self.tasks: List[dict] = []
         self.completed_tasks: List[dict] = []

--- a/src/course.py
+++ b/src/course.py
@@ -43,18 +43,34 @@ class Course:
         self.name: str = name
         self.description: str = description
         self.code: str = code
-        if not isinstance(start_date, date):
-            raise TypeError("Start Date must be a date object")
-        self.start_date: date = start_date
-        if not isinstance(end_date, date):
-            raise TypeError("Start Date must be a date object")
-        self.end_date: date = end_date
+        try:
+            self.start_date: date = start_date
+        except ValueError:
+            raise ValueError("Invalid start date")
+        try:
+            self.end_date: date = end_date
+        except ValueError:
+            raise ValueError("Invalid end date")
         self.tasks: List[dict] = []
         self.completed_tasks: List[dict] = []
 
     def __str__(self):
         """Returns human-readable string for print() functions"""
-        return "{" + str(self.id) + ", " + self.name + ", " + self.description + ", " + self.code + ", " + self.start_date.strftime("%Y/%m/%d") + ", " + self.end_date.strftime("%Y/%m/%d") + "}"
+        return (
+            "{"
+            + str(self.id)
+            + ", "
+            + self.name
+            + ", "
+            + self.description
+            + ", "
+            + self.code
+            + ", "
+            + self.start_date.strftime("%Y/%m/%d")
+            + ", "
+            + self.end_date.strftime("%Y/%m/%d")
+            + "}"
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert Course instance to dictionary for JSON serialization."""
@@ -94,7 +110,7 @@ class CourseList:
         string = string[:-2]
         string += "]"
         return string
-        
+
     def _create_course_from_dict(self, course_data: Dict[str, Any]) -> Course:
         """
         Create a Course instance from a dictionary.

--- a/src/course.py
+++ b/src/course.py
@@ -50,7 +50,7 @@ class Course:
 
     def __str__(self):
         """Returns human-readable string for print() functions"""
-        return "{" + str(self.id) + ", " + self.name + ", " + self.description + ", " + self.code + ", " + self.start_date + ", " + self.end_date + "}"
+        return "{" + str(self.id) + ", " + self.name + ", " + self.description + ", " + self.code + ", " + self.start_date.strftime("%Y/%m/%d") + ", " + self.end_date.strftime("%Y/%m/%d") + "}"
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert Course instance to dictionary for JSON serialization."""

--- a/src/course.py
+++ b/src/course.py
@@ -1,5 +1,6 @@
 import json
 from typing import List, Optional, Dict, Any
+from datetime import date
 
 COURSE_FILE = "courses.json"
 
@@ -24,8 +25,8 @@ class Course:
         name: str,
         description: str,
         code: str,
-        start_date: str,
-        end_date: str,
+        start_date: date,
+        end_date: date,
     ):
         """
         Initialize a new Course instance.
@@ -42,8 +43,8 @@ class Course:
         self.name: str = name
         self.description: str = description
         self.code: str = code
-        self.start_date: str = start_date
-        self.end_date: str = end_date
+        self.start_date: date = start_date
+        self.end_date: date = end_date
         self.tasks: List[dict] = []
         self.completed_tasks: List[dict] = []
 

--- a/src/course.py
+++ b/src/course.py
@@ -43,14 +43,12 @@ class Course:
         self.name: str = name
         self.description: str = description
         self.code: str = code
-        try:
-            self.start_date: date = start_date
-        except ValueError:
-            raise ValueError("Invalid start date")
-        try:
-            self.end_date: date = end_date
-        except ValueError:
-            raise ValueError("Invalid end date")
+        if not isinstance(start_date, date):
+            raise TypeError("Start Date must be a date object")
+        self.start_date: date = start_date
+        if not isinstance(end_date, date):
+            raise TypeError("Start Date must be a date object")
+        self.end_date: date = end_date
         self.tasks: List[dict] = []
         self.completed_tasks: List[dict] = []
 

--- a/src/course.py
+++ b/src/course.py
@@ -63,8 +63,8 @@ class Course:
             "name": self.name,
             "description": self.description,
             "code": self.code,
-            "start_date": self.start_date,
-            "end_date": self.end_date,
+            "start_date": self.start_date.isoformat(),
+            "end_date": self.end_date.isoformat(),
             "tasks": self.tasks,
             "completed_tasks": self.completed_tasks,
         }
@@ -114,6 +114,8 @@ class CourseList:
             "start_date": course_data["start_date"],
             "end_date": course_data["end_date"],
         }
+        core_attrs["start_date"] = date.fromisoformat(core_attrs["start_date"])
+        core_attrs["end_date"] = date.fromisoformat(core_attrs["end_date"])
 
         # Create course instance
         course = Course(**core_attrs)

--- a/src/gui/components/add_course_view.py
+++ b/src/gui/components/add_course_view.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
-from datetime import datetime
+from datetime import date
 from tkinter import messagebox
 from .custom_button import CustomButton
 
@@ -102,13 +102,21 @@ class AddCourseView(tk.Toplevel):
             elif not self.code_entry.get():
                 messagebox.showinfo("Error", "Course code cannot be empty")
                 raise ValueError("Course code cannot be empty")
+            try:
+                start_date = date.fromisoformat(self.start_date_entry.get())
+            except ValueError as e:
+                raise ValueError(f"{self.start_date_entry.get()} is not a valid YYYY-MM-DD date")
+            try:
+                end_date = date.fromisoformat(self.end_date_entry.get())
+            except ValueError as e:
+                raise ValueError(f"{self.end_date_entry.get()} is not a valid YYYY-MM-DD date")
 
             course_data = {
                 "name": self.name_entry.get(),
                 "code": self.code_entry.get(),
                 "description": self.description_text.get("1.0", "end-1c"),
-                "start_date": self.start_date_entry.get(),
-                "end_date": self.end_date_entry.get(),
+                "start_date": start_date,
+                "end_date": end_date,
             }
             self.save_callback(course_data)
         self.destroy()

--- a/src/gui/components/add_course_view.py
+++ b/src/gui/components/add_course_view.py
@@ -1,8 +1,10 @@
 import tkinter as tk
-from tkinter import ttk
+from tkinter import *
 from datetime import date
 from tkinter import messagebox
 from .custom_button import CustomButton
+
+# from tkcalendar import Calendar # Add tkcalendar for date input
 
 
 class AddCourseView(tk.Toplevel):
@@ -99,17 +101,38 @@ class AddCourseView(tk.Toplevel):
             if not self.name_entry.get():
                 messagebox.showinfo("Error", "Course name cannot be empty")
                 raise ValueError("Course name cannot be empty")
-            elif not self.code_entry.get():
+
+            if not self.code_entry.get():
                 messagebox.showinfo("Error", "Course code cannot be empty")
                 raise ValueError("Course code cannot be empty")
+
+            if not self.start_date_entry.get():
+                messagebox.showinfo("Error", "Start date cannot be empty")
+                raise ValueError("Start date cannot be empty")
             try:
                 start_date = date.fromisoformat(self.start_date_entry.get())
-            except ValueError as e:
-                raise ValueError(f"{self.start_date_entry.get()} is not a valid YYYY-MM-DD date")
+            except ValueError:
+                messagebox.showinfo(
+                    "Error",
+                    f"{self.start_date_entry.get()} is not a valid YYYY-MM-DD date",
+                )
+                raise ValueError(
+                    f"{self.start_date_entry.get()} is not a valid YYYY-MM-DD date"
+                )
+
+            if not self.end_date_entry.get():
+                messagebox.showinfo("Error", "End date cannot be empty")
+                raise ValueError("End date cannot be empty")
             try:
                 end_date = date.fromisoformat(self.end_date_entry.get())
-            except ValueError as e:
-                raise ValueError(f"{self.end_date_entry.get()} is not a valid YYYY-MM-DD date")
+            except ValueError:
+                messagebox.showinfo(
+                    "Error",
+                    f"{self.end_date_entry.get()} is not a valid YYYY-MM-DD date",
+                )
+                raise ValueError(
+                    f"{self.end_date_entry.get()} is not a valid YYYY-MM-DD date"
+                )
 
             course_data = {
                 "name": self.name_entry.get(),

--- a/src/gui/components/edit_task_view.py
+++ b/src/gui/components/edit_task_view.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
-from datetime import datetime
+from datetime import date
 from .custom_button import CustomButton
 
 
@@ -115,7 +115,7 @@ class EditTaskView(tk.Toplevel):
         if self.save_callback:
             task_data = {
                 "name": self.name_entry.get(),
-                "due_date": self.due_date_entry.get(),
+                "due_date": date.fromisoformat(self.due_date_entry.get()),
                 "description": self.description_text.get("1.0", "end-1c"),
                 "status": self.status_var.get(),
                 "course": self.course_var.get(),  # Add course to task data

--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -8,7 +8,7 @@ from components.add_task_view import AddTaskView
 from components.add_course_view import AddCourseView
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
 # Add the src directory to the Python path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -112,7 +112,7 @@ class TaskManagerGUI:
                     task_id=self.next_task_id,
                     title=task_data["name"],
                     description=task_data["description"],
-                    due_date=task_data["due_date"],
+                    due_date=date.fromisoformat(task_data["due_date"]),
                     course_id=task_data["course"],
                     status=task_data["status"],
                 )

--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -68,18 +68,10 @@ class TaskManagerGUI:
                 # Check if course already exists
                 for course in self.course_list.courses:
                     if new_course.name == course.name:
-                        messagebox.showinfo(
-                            "Error",
-                            f"Course name \"{course_data['name']}\" already exists",
-                        )
                         raise ValueError(
                             f"Course name \"{course_data['name']}\" already exists"
                         )
                     elif new_course.code == course.code:
-                        messagebox.showinfo(
-                            "Error",
-                            f"Course code \"{course_data['code']}\" already exists",
-                        )
                         raise ValueError(
                             f"Course code \"{course_data['code']}\" already exists"
                         )
@@ -123,10 +115,6 @@ class TaskManagerGUI:
                         new_task.title == task.title
                         and new_task.course_id == task.course_id
                     ):
-                        messagebox.showinfo(
-                            "Error",
-                            f"Task name \"{task_data['name']}\" in course \"{task_data['course']}\" already exists",
-                        )
                         raise ValueError(
                             f"Task name \"{task_data['name']}\" in course \"{task_data['course']}\" already exists"
                         )

--- a/src/main.py
+++ b/src/main.py
@@ -114,7 +114,7 @@ def create_task() -> None:
         description=input("Enter task description: "),
         due_date=input("Enter due date: "),
         course_id=course_id,
-        status="pending"
+        status="pending",
     )
     tasks.append(new_task)
     Task.save_tasks(tasks)

--- a/src/task.py
+++ b/src/task.py
@@ -1,5 +1,6 @@
 import json
 from typing import List, Dict, Any
+from datetime import date
 
 TASK_FILE = "tasks.json"
 
@@ -11,7 +12,7 @@ class Task:
         task_id: int,
         title: str,
         description: str,
-        due_date: str,
+        due_date: date,
         course_id: int,
         status: str = "pending",
     ):
@@ -29,13 +30,13 @@ class Task:
         self.task_id: int = task_id
         self.title: str = title
         self.description: str = description
-        self.due_date: str = due_date
+        self.due_date: date = due_date
         self.course_id: int = course_id
         self.status: str = status
 
     @staticmethod
     def create_task(
-        task_id: int, title: str, description: str, due_date: str, course_id: int
+        task_id: int, title: str, description: str, due_date: date, course_id: int
     ) -> "Task":
         """
         Create a new Task instance.
@@ -52,7 +53,7 @@ class Task:
         """
         return Task(task_id, title, description, due_date, course_id)
 
-    def get_task_details(self) -> Dict[str, str]:
+    def get_task_details(self) -> Dict[str, int | date | str]:
         """
         Get task details as a dictionary.
 

--- a/src/task.py
+++ b/src/task.py
@@ -34,6 +34,10 @@ class Task:
         self.course_id: int = course_id
         self.status: str = status
 
+    def __str__(self):
+        """Returns human-readable string for print() functions"""
+        return "{" + str(self.task_id) + ", " + self.title + ", " + self.description + ", " + self.due_date.strftime("%Y/%m/%d") + ", " + str(self.course_id) + ", " + self.status + "}"
+    
     @staticmethod
     def create_task(
         task_id: int, title: str, description: str, due_date: date, course_id: int

--- a/src/task.py
+++ b/src/task.py
@@ -114,14 +114,15 @@ class Task:
         try:
             with open(TASK_FILE, "r") as file:
                 tasks_data = json.load(file)
-                return [cls(
+                tasks = [cls(
                     task_id=task["task_id"],
                     title=task["title"],
                     description=task["description"],
-                    due_date=task["due_date"],
+                    due_date=date.fromisoformat(task["due_date"]),
                     course_id=task["course_id"],
                     status=task["status"]
                 ) for task in tasks_data]
+                return tasks
         except FileNotFoundError:
             return []
 

--- a/src/task.py
+++ b/src/task.py
@@ -4,6 +4,7 @@ from datetime import date
 
 TASK_FILE = "tasks.json"
 
+
 class Task:
     """A class representing a task associated with a course."""
 
@@ -38,8 +39,22 @@ class Task:
 
     def __str__(self):
         """Returns human-readable string for print() functions"""
-        return "{" + str(self.task_id) + ", " + self.title + ", " + self.description + ", " + self.due_date.strftime("%Y/%m/%d") + ", " + str(self.course_id) + ", " + self.status + "}"
-    
+        return (
+            "{"
+            + str(self.task_id)
+            + ", "
+            + self.title
+            + ", "
+            + self.description
+            + ", "
+            + self.due_date.strftime("%Y/%m/%d")
+            + ", "
+            + str(self.course_id)
+            + ", "
+            + self.status
+            + "}"
+        )
+
     @staticmethod
     def create_task(
         task_id: int, title: str, description: str, due_date: date, course_id: int
@@ -114,14 +129,17 @@ class Task:
         try:
             with open(TASK_FILE, "r") as file:
                 tasks_data = json.load(file)
-                tasks = [cls(
-                    task_id=task["task_id"],
-                    title=task["title"],
-                    description=task["description"],
-                    due_date=date.fromisoformat(task["due_date"]),
-                    course_id=task["course_id"],
-                    status=task["status"]
-                ) for task in tasks_data]
+                tasks = [
+                    cls(
+                        task_id=task["task_id"],
+                        title=task["title"],
+                        description=task["description"],
+                        due_date=date.fromisoformat(task["due_date"]),
+                        course_id=task["course_id"],
+                        status=task["status"],
+                    )
+                    for task in tasks_data
+                ]
                 return tasks
         except FileNotFoundError:
             return []
@@ -141,7 +159,7 @@ class Task:
             "description": self.description,
             "due_date": self.due_date.isoformat(),
             "course_id": self.course_id,
-            "status": self.status
+            "status": self.status,
         }
 
     @classmethod
@@ -153,8 +171,7 @@ class Task:
             description=data["description"],
             due_date=data["due_date"],
             course_id=data["course_id"],
-            status=data["status"]
-            )
+            status=data["status"],
+        )
         core_attrs["due_date"] = date.fromisoformat(core_attrs["due_date"])
         return core_attrs
-        

--- a/src/task.py
+++ b/src/task.py
@@ -30,6 +30,8 @@ class Task:
         self.task_id: int = task_id
         self.title: str = title
         self.description: str = description
+        if not isinstance(due_date, date):
+            raise TypeError("Due Date must be a date object")
         self.due_date: date = due_date
         self.course_id: int = course_id
         self.status: str = status

--- a/src/task.py
+++ b/src/task.py
@@ -59,22 +59,6 @@ class Task:
         """
         return Task(task_id, title, description, due_date, course_id)
 
-    def get_task_details(self) -> Dict[str, int | date | str]:
-        """
-        Get task details as a dictionary.
-
-        Returns:
-            Dict[str, str]: Dictionary containing task details
-        """
-        return {
-            "task_id": self.task_id,
-            "title": self.title,
-            "description": self.description,
-            "due_date": self.due_date,
-            "course_id": self.course_id,
-            "status": self.status,
-        }
-
     def update_task(self, **kwargs) -> "Task":
         """
         Update task attributes using keyword arguments.
@@ -144,7 +128,7 @@ class Task:
     @staticmethod
     def save_tasks(tasks: List["Task"]) -> None:
         """Save tasks to JSON file"""
-        tasks_data = [task.get_task_details() for task in tasks]
+        tasks_data = [task.to_dict() for task in tasks]
         with open(TASK_FILE, "w") as file:
             json.dump(tasks_data, file, indent=4)
 
@@ -154,7 +138,7 @@ class Task:
             "task_id": self.task_id,
             "title": self.title,
             "description": self.description,
-            "due_date": self.due_date,
+            "due_date": self.due_date.isoformat(),
             "course_id": self.course_id,
             "status": self.status
         }
@@ -162,11 +146,14 @@ class Task:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Task":
         """Create Task instance from dictionary"""
-        return cls(
+        core_attrs = cls(
             task_id=data["task_id"],
             title=data["title"],
             description=data["description"],
             due_date=data["due_date"],
             course_id=data["course_id"],
             status=data["status"]
-        )
+            )
+        core_attrs["due_date"] = date.fromisoformat(core_attrs["due_date"])
+        return core_attrs
+        

--- a/test/course_tests.py
+++ b/test/course_tests.py
@@ -195,18 +195,14 @@ class TestCourseMethods(unittest.TestCase):
         print("Course added successfully")
         print()
 
-    # NEED TO CHANGE THIS TEST
+    def make_course_with_str_dates(self):
+        course = Course(1, "Test Course", "This is a test course", "TC101", "", "")
+
     def test_add_course_with_empty_dates(self):
         # Test adding a course with empty start and end dates
-        print("Running test to add a course with empty start and end dates")
-        course = Course(1, "Test Course", "This is a test course", "TC101", "", "")
-        print("Course added:", end=" ")
-        print(course)
-        self.assertEqual(
-            course.start_date, "", "ERROR: course.start_date should be empty"
-        )
-        self.assertEqual(course.end_date, "", "ERROR: course.end_date should be empty")
-        print("Course added successfully")
+        print("Running test to add a course with string dates")
+        self.assertRaises(TypeError, self.make_course_with_str_dates)
+        print("Course caused a TypeError correctly")
         print()
 
     def test_delete_non_existent_course(self):

--- a/test/course_tests.py
+++ b/test/course_tests.py
@@ -42,12 +42,12 @@ class TestCourseMethods(unittest.TestCase):
         )
         self.assertEqual(
             course.start_date,
-            "2023-06-01",
+            date.fromisoformat("2023-06-01"),
             "ERROR: course.start_date was added unsuccessfully",
         )
         self.assertEqual(
             course.end_date,
-            "2023-06-30",
+            date.fromisoformat("2023-06-30"),
             "ERROR: course.end_date was added unsuccessfully",
         )
         print("Course added successfully")
@@ -396,7 +396,7 @@ class TestCourseMethods(unittest.TestCase):
             "ERROR: course.start_date edit unsuccessful",
         )
         self.assertEqual(
-            course.end_date, "2023-07-31", "ERROR: course.end_date edit unsuccessful"
+            course.end_date, date.fromisoformat("2023-07-31"), "ERROR: course.end_date edit unsuccessful"
         )
         print("course.start_date and course.end_date successfully edited")
         print()

--- a/test/course_tests.py
+++ b/test/course_tests.py
@@ -396,7 +396,9 @@ class TestCourseMethods(unittest.TestCase):
             "ERROR: course.start_date edit unsuccessful",
         )
         self.assertEqual(
-            course.end_date, date.fromisoformat("2023-07-31"), "ERROR: course.end_date edit unsuccessful"
+            course.end_date,
+            date.fromisoformat("2023-07-31"),
+            "ERROR: course.end_date edit unsuccessful",
         )
         print("course.start_date and course.end_date successfully edited")
         print()

--- a/test/course_tests.py
+++ b/test/course_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 from src.course import Course, CourseList, COURSE_FILE
+from datetime import date
 
 
 class TestCourseMethods(unittest.TestCase):
@@ -23,16 +24,32 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("Course added:", end=" ")
         print(course)
-        self.assertEqual(course.name, "Test Course", "ERROR: course.name was added unsuccessfully")
-        self.assertEqual(course.description, "This is a test course", "ERROR: course.description was added unsuccessfully")
-        self.assertEqual(course.code, "TC101", "ERROR: course.code was added unsuccessfully")
-        self.assertEqual(course.start_date, "2023-06-01", "ERROR: course.start_date was added unsuccessfully")
-        self.assertEqual(course.end_date, "2023-06-30", "ERROR: course.end_date was added unsuccessfully")
+        self.assertEqual(
+            course.name, "Test Course", "ERROR: course.name was added unsuccessfully"
+        )
+        self.assertEqual(
+            course.description,
+            "This is a test course",
+            "ERROR: course.description was added unsuccessfully",
+        )
+        self.assertEqual(
+            course.code, "TC101", "ERROR: course.code was added unsuccessfully"
+        )
+        self.assertEqual(
+            course.start_date,
+            "2023-06-01",
+            "ERROR: course.start_date was added unsuccessfully",
+        )
+        self.assertEqual(
+            course.end_date,
+            "2023-06-30",
+            "ERROR: course.end_date was added unsuccessfully",
+        )
         print("Course added successfully")
         print()
 
@@ -45,15 +62,21 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         course_list.add_course(course)
         self.assertIn(course, course_list.courses, "ERROR: Course is not found in list")
         print(course_list.courses[0].name)
-        print("CourseList created:", end =" ")
+        print("CourseList created:", end=" ")
         print(course_list)
-        self.assertEqual(len(course_list.courses), 1, "ERROR: Expected to have only 1 Course object, but got " + str(len(course_list.courses)) + " instead")
+        self.assertEqual(
+            len(course_list.courses),
+            1,
+            "ERROR: Expected to have only 1 Course object, but got "
+            + str(len(course_list.courses))
+            + " instead",
+        )
         print("Course added successfully to list")
         print()
 
@@ -66,14 +89,24 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         course_list.add_course(course)
         self.assertIn(course, course_list.courses, "ERROR: Course not found in list")
         course_list.delete_course(1)
-        self.assertNotIn(course, course_list.courses, "ERROR: Course should be deleted, but still exists")
-        self.assertEqual(len(course_list.courses), 0, "ERROR: list should be empty, but found " + str(len(course_list.courses)) + " object(s)")
+        self.assertNotIn(
+            course,
+            course_list.courses,
+            "ERROR: Course should be deleted, but still exists",
+        )
+        self.assertEqual(
+            len(course_list.courses),
+            0,
+            "ERROR: list should be empty, but found "
+            + str(len(course_list.courses))
+            + " object(s)",
+        )
         print("Course deleted successfully from CourseList")
         print()
 
@@ -85,20 +118,26 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("Course added:", end=" ")
         print(course)
         course.name = "Updated Test Course"
         course.description = "This is an updated test course"
         course.code = "TC102"
-        course.start_date = "2023-07-01"
-        course.end_date = "2023-07-31"
+        course.start_date = date.fromisoformat("2023-07-01")
+        course.end_date = date.fromisoformat("2023-07-31")
         print("Course after editing:", end=" ")
         print(course)
-        self.assertEqual(course.name, "Updated Test Course", "ERROR: Unable to change course.name")
-        self.assertEqual(course.description, "This is an updated test course", "ERROR: Unable to change course.description")
+        self.assertEqual(
+            course.name, "Updated Test Course", "ERROR: Unable to change course.name"
+        )
+        self.assertEqual(
+            course.description,
+            "This is an updated test course",
+            "ERROR: Unable to change course.description",
+        )
         self.assertEqual(course.code, "TC102", "ERROR: Unable to change course.code")
         print("Course edited successfully")
         print()
@@ -107,7 +146,12 @@ class TestCourseMethods(unittest.TestCase):
         # Test adding a course with an empty name
         print("Running test to add a course with an empty name")
         course = Course(
-            1, "", "This is a test course", "TC101", "2023-06-01", "2023-06-30"
+            1,
+            "",
+            "This is a test course",
+            "TC101",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("Course added:", end=" ")
         print(course)
@@ -118,10 +162,19 @@ class TestCourseMethods(unittest.TestCase):
     def test_add_course_with_empty_description(self):
         # Test adding a course with an empty description
         print("Running test to add a course with an empty description")
-        course = Course(1, "Test Course", "", "TC101", "2023-06-01", "2023-06-30")
+        course = Course(
+            1,
+            "Test Course",
+            "",
+            "TC101",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
+        )
         print("Course added:", end=" ")
         print(course)
-        self.assertEqual(course.description, "", "ERROR: course.description should be empty")
+        self.assertEqual(
+            course.description, "", "ERROR: course.description should be empty"
+        )
         print("Course added successfully")
         print()
 
@@ -129,7 +182,12 @@ class TestCourseMethods(unittest.TestCase):
         # Test adding a course with an empty code
         print("Running test to add a course with an empty code")
         course = Course(
-            1, "Test Course", "This is a test course", "", "2023-06-01", "2023-06-30"
+            1,
+            "Test Course",
+            "This is a test course",
+            "",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("Course added:", end=" ")
         print(course)
@@ -137,46 +195,63 @@ class TestCourseMethods(unittest.TestCase):
         print("Course added successfully")
         print()
 
+    # NEED TO CHANGE THIS TEST
     def test_add_course_with_empty_dates(self):
         # Test adding a course with empty start and end dates
         print("Running test to add a course with empty start and end dates")
         course = Course(1, "Test Course", "This is a test course", "TC101", "", "")
         print("Course added:", end=" ")
         print(course)
-        self.assertEqual(course.start_date, "", "ERROR: course.start_date should be empty")
+        self.assertEqual(
+            course.start_date, "", "ERROR: course.start_date should be empty"
+        )
         self.assertEqual(course.end_date, "", "ERROR: course.end_date should be empty")
         print("Course added successfully")
         print()
 
     def test_delete_non_existent_course(self):
         # Test deleting a non-existent course from the CourseList
-        print("Running test to delete a non-existent course from the CourseList, which the existing Course object in CourseList should not be deleted")
+        print(
+            "Running test to delete a non-existent course from the CourseList, which the existing Course object in CourseList should not be deleted"
+        )
         course_list = CourseList()
         course = Course(
             1,
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         course_list.add_course(course)
         course_list.delete_course(2)
-        self.assertIn(course, course_list.courses, "ERROR: Course with course.id of 1 should not be deleted")
-        self.assertEqual(len(course_list.courses), 1, "ERROR: course_list should only have 1 course, but " + str(len(course_list.courses)) + " was found")
+        self.assertIn(
+            course,
+            course_list.courses,
+            "ERROR: Course with course.id of 1 should not be deleted",
+        )
+        self.assertEqual(
+            len(course_list.courses),
+            1,
+            "ERROR: course_list should only have 1 course, but "
+            + str(len(course_list.courses))
+            + " was found",
+        )
         print("Success! Existing course is not deleted")
         print()
 
     def test_edit_course_with_invalid_field(self):
         # Test editing a course with an invalid field
-        print("Running test to edit a course with an invalid field, which should throw an error")
+        print(
+            "Running test to edit a course with an invalid field, which should throw an error"
+        )
         course = Course(
             1,
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         # Instead of using vars(), we'll check slots
         expected_attrs = {
@@ -190,9 +265,13 @@ class TestCourseMethods(unittest.TestCase):
             "completed_tasks",
         }
         actual_attrs = set(course.__slots__)
-        self.assertEqual(expected_attrs, actual_attrs, "ERROR: course.__slots__ does not match the original set")
+        self.assertEqual(
+            expected_attrs,
+            actual_attrs,
+            "ERROR: course.__slots__ does not match the original set",
+        )
         # Test that we can't add new attributes
-        print("Attempting to edit field \"invalid_field\"")
+        print('Attempting to edit field "invalid_field"')
         with self.assertRaises(AttributeError):
             course.invalid_field = "Invalid"
         print("AttributeError successfully thrown, test passed")
@@ -200,15 +279,17 @@ class TestCourseMethods(unittest.TestCase):
 
     def test_add_course_with_duplicate_id(self):
         # Test adding a course with a duplicate ID
-        print("Running test to add a course with a duplicate ID, which should throw an error")
+        print(
+            "Running test to add a course with a duplicate ID, which should throw an error"
+        )
         course_list = CourseList()
         course1 = Course(
             1,
             "Test Course 1",
             "This is a test course 1",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("course1 added:", end=" ")
         print(course1)
@@ -217,8 +298,8 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course 2",
             "This is a test course 2",
             "TC102",
-            "2023-07-01",
-            "2023-07-31",
+            date.fromisoformat("2023-07-01"),
+            date.fromisoformat("2023-07-31"),
         )
         print("course2 added:", end=" ")
         print(course2)
@@ -229,7 +310,6 @@ class TestCourseMethods(unittest.TestCase):
             course_list.add_course(course2)
         print("Success! ValueError is thrown due to the duplicate course_id")
         print()
-        
 
     def test_edit_course_name(self):
         # Test editing a course name
@@ -239,15 +319,17 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("Course added:", end=" ")
         print(course)
         course.name = "New Course Name"
         print("Course after editing:", end=" ")
         print(course)
-        self.assertEqual(course.name, "New Course Name", "ERROR: course.name edit unsuccessful")
+        self.assertEqual(
+            course.name, "New Course Name", "ERROR: course.name edit unsuccessful"
+        )
         print("course.name successfully edited")
         print()
 
@@ -259,15 +341,19 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("Course added:", end=" ")
         print(course)
         course.description = "New Course Description"
         print("Course after editing:", end=" ")
         print(course)
-        self.assertEqual(course.description, "New Course Description", "ERROR: course.description edit unsuccessful")
+        self.assertEqual(
+            course.description,
+            "New Course Description",
+            "ERROR: course.description edit unsuccessful",
+        )
         print("course.description successfully edited")
         print()
 
@@ -279,8 +365,8 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("Course added:", end=" ")
         print(course)
@@ -299,17 +385,23 @@ class TestCourseMethods(unittest.TestCase):
             "Test Course",
             "This is a test course",
             "TC101",
-            "2023-06-01",
-            "2023-06-30",
+            date.fromisoformat("2023-06-01"),
+            date.fromisoformat("2023-06-30"),
         )
         print("Course added:", end=" ")
         print(course)
-        course.start_date = "2023-07-01"
-        course.end_date = "2023-07-31"
+        course.start_date = date.fromisoformat("2023-07-01")
+        course.end_date = date.fromisoformat("2023-07-31")
         print("Course after editing:", end=" ")
         print(course)
-        self.assertEqual(course.start_date, "2023-07-01", "ERROR: course.start_date edit unsuccessful")
-        self.assertEqual(course.end_date, "2023-07-31", "ERROR: course.end_date edit unsuccessful")
+        self.assertEqual(
+            course.start_date,
+            date.fromisoformat("2023-07-01"),
+            "ERROR: course.start_date edit unsuccessful",
+        )
+        self.assertEqual(
+            course.end_date, "2023-07-31", "ERROR: course.end_date edit unsuccessful"
+        )
         print("course.start_date and course.end_date successfully edited")
         print()
 

--- a/test/task_tests.py
+++ b/test/task_tests.py
@@ -4,8 +4,8 @@ import json
 from datetime import date
 from src.task import Task
 from src.main import (
-    load_tasks,
-    save_tasks,
+    # load_tasks,
+    # save_tasks,
     filter_tasks_by_due_date,
     filter_tasks_by_course,
     sort_tasks_by_due_date,
@@ -35,7 +35,7 @@ class TestTaskMethods(unittest.TestCase):
         task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
-        details = task.get_task_details()
+        details = task.to_dict()
         self.assertEqual(details["title"], "Test Task", "ERROR: unable to get task.title, or field is incorrect")
         self.assertEqual(details["description"], "This is a test task", "ERROR: unable to get task.description, or field is incorrect")
         self.assertEqual(details["due_date"], date.fromisoformat("2023-06-01"), "ERROR: unable to get task.due_date, or field is incorrect")
@@ -144,7 +144,7 @@ class TestTaskMethods(unittest.TestCase):
     def test_create_task_with_empty_due_date(self):
         # Test creating a task with a strinh due date
         print("Running test to add a task with string date")
-        self.assertRaises(TypeError, self.make_course_with_str_dates)
+        self.assertRaises(TypeError, self.make_task_with_str_dates)
         print("Task caused a TypeError correctly")
         print()
 

--- a/test/task_tests.py
+++ b/test/task_tests.py
@@ -3,14 +3,6 @@ from unittest.mock import patch, mock_open
 import json
 from datetime import date
 from src.task import Task
-from src.main import (
-    # load_tasks,
-    # save_tasks,
-    filter_tasks_by_due_date,
-    filter_tasks_by_course,
-    sort_tasks_by_due_date,
-    sort_tasks_by_course_id,
-)
 
 
 class TestTaskMethods(unittest.TestCase):
@@ -200,95 +192,6 @@ class TestTaskMethods(unittest.TestCase):
         self.assertIn(task1, tasks_list, "ERROR: task1 should still be in the list")
         self.assertEqual(len(tasks_list), 1, "ERROR: tasks_list should only have 1 object, but " + str(len(tasks_list)) + "was found")
         print("Success! existing Task task1 was not deleted")
-        print()
-
-
-class TestSortingMethods(unittest.TestCase):
-
-    @patch("src.main.save_tasks")
-    @patch("src.main.open", new_callable=mock_open)
-    def test_sort_tasks_by_due_date(self, mock_file, mock_save_tasks):
-        # Test sorting tasks by due date
-        print("Running test to sort tasks by due date")
-        task1 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
-        task2 = Task(2, "Task B", "This is Task B", date.fromisoformat("2023-06-11"), 1)
-        task3 = Task(3, "Task C", "This is Task C", date.fromisoformat("2023-06-05"), 1)
-        mock_tasks = [task1.__dict__, task2.__dict__, task3.__dict__]
-
-        # Mock file reading with JSON data
-        mock_file.return_value.read.return_value = json.dumps(mock_tasks)
-        sort_tasks_by_due_date()
-        mock_save_tasks.assert_called_once()
-        sorted_tasks = mock_save_tasks.call_args[0][0]
-
-        self.assertEqual(sorted_tasks[0]["task_id"], 1, "ERROR: Wrong order! task should be sorted to the 1st")
-        self.assertEqual(sorted_tasks[1]["task_id"], 3, "ERROR: Wrong order! task should be sorted to the 2nd")
-        self.assertEqual(sorted_tasks[2]["task_id"], 2, "ERROR: Wrong order! task should be sorted to the 3rd")
-        print("Sort successful")
-        print()
-
-    @patch("src.main.save_tasks")
-    @patch("src.main.open", new_callable=mock_open)
-    def test_sort_tasks_by_course_id(self, mock_file, mock_save_tasks):
-        # Test sorting tasks by course id
-        print("Running test to sort tasks by course id")
-        task1 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 4)
-        task2 = Task(2, "Task B", "This is Task B", date.fromisoformat("2023-06-11"), 8)
-        task3 = Task(3, "Task C", "This is Task C", date.fromisoformat("2023-06-05"), 2)
-        mock_tasks = [task1.__dict__, task2.__dict__, task3.__dict__]
-
-        # Mock file reading with JSON data
-        mock_file.return_value.read.return_value = json.dumps(mock_tasks)
-        sort_tasks_by_course_id()
-        mock_save_tasks.assert_called_once()
-        sorted_tasks = mock_save_tasks.call_args[0][0]
-
-        self.assertEqual(sorted_tasks[0]["course_id"], 2, "ERROR: Wrong order! task should be sorted to the 1st")
-        self.assertEqual(sorted_tasks[1]["course_id"], 4, "ERROR: Wrong order! task should be sorted to the 2nd")
-        self.assertEqual(sorted_tasks[2]["course_id"], 8, "ERROR: Wrong order! task should be sorted to the 3rd")
-        print("Sort successful")
-        print()
-
-    @patch("src.main.save_tasks")
-    @patch("src.main.open", new_callable=mock_open)
-    def test_sort_tasks_by_due_date_all_same(self, mock_file, mock_save_tasks):
-        print("Running test to sort tasks by due date, but all have the same due date")
-        task1 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
-        task2 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 2)
-        task3 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 3)
-        mock_tasks = [task1.__dict__, task2.__dict__, task3.__dict__]
-
-        # Mock file reading with JSON data
-        mock_file.return_value.read.return_value = json.dumps(mock_tasks)
-        sort_tasks_by_due_date()
-        mock_save_tasks.assert_called_once()
-        sorted_tasks = mock_save_tasks.call_args[0][0]
-
-        self.assertEqual(sorted_tasks[0]["task_id"], 1, "ERROR: task_id is not 1, all 3 tasks should have id of 1 for this test")
-        self.assertEqual(sorted_tasks[1]["task_id"], 1, "ERROR: task_id is not 1, all 3 tasks should have id of 1 for this test")
-        self.assertEqual(sorted_tasks[2]["task_id"], 1, "ERROR: task_id is not 1, all 3 tasks should have id of 1 for this test")
-        print("Sort successful")
-        print()
-
-    @patch("src.main.save_tasks")
-    @patch("src.main.open", new_callable=mock_open)
-    def test_sort_tasks_by_course_id_all_same(self, mock_file, mock_save_tasks):
-        print("Running test to sort tasks by course id, but all have the same course id")
-        task1 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
-        task2 = Task(2, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
-        task3 = Task(3, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
-        mock_tasks = [task1.__dict__, task2.__dict__, task3.__dict__]
-
-        # Mock file reading with JSON data
-        mock_file.return_value.read.return_value = json.dumps(mock_tasks)
-        sort_tasks_by_due_date()
-        mock_save_tasks.assert_called_once()
-        sorted_tasks = mock_save_tasks.call_args[0][0]
-
-        self.assertEqual(sorted_tasks[0]["course_id"], 1, "ERROR: course_id is not 1, all 3 course should have id of 1 for this test")
-        self.assertEqual(sorted_tasks[1]["course_id"], 1, "ERROR: course_id is not 1, all 3 course should have id of 1 for this test")
-        self.assertEqual(sorted_tasks[2]["course_id"], 1, "ERROR: course_id is not 1, all 3 course should have id of 1 for this test")
-        print("Sort successful")
         print()
 
 

--- a/test/task_tests.py
+++ b/test/task_tests.py
@@ -30,7 +30,10 @@ class TestTaskMethods(unittest.TestCase):
         details = task.to_dict()
         self.assertEqual(details["title"], "Test Task", "ERROR: unable to get task.title, or field is incorrect")
         self.assertEqual(details["description"], "This is a test task", "ERROR: unable to get task.description, or field is incorrect")
-        self.assertEqual(details["due_date"], date.fromisoformat("2023-06-01"), "ERROR: unable to get task.due_date, or field is incorrect")
+        # date should be a string here, and nowhere else, because the method we are testing
+        # is for preparing the task for JSON saving. JSON cannot save date objects, so we 
+        # make it into an ISO format string.
+        self.assertEqual(details["due_date"], "2023-06-01", "ERROR: unable to get task.due_date, or field is incorrect")
         self.assertEqual(details["course_id"], 1, "ERROR: unable to get task.course_id, or field is incorrect")
         self.assertEqual(details["status"], "pending", "ERROR: unable to get task.status flag, or field is incorrect")
         print("Details succefully got")

--- a/test/task_tests.py
+++ b/test/task_tests.py
@@ -138,14 +138,14 @@ class TestTaskMethods(unittest.TestCase):
         print("Task successfully created")
         print()
 
+    def make_task_with_str_dates(self):
+        task = Task(1, "Test Task", "This is a test task", "", 1)
+
     def test_create_task_with_empty_due_date(self):
-        # Test creating a task with an empty due date
-        print("Running test to create a task with a nempty due date")
-        task = Task.create_task(1, "Test Task", "This is a test task", "", 1)
-        print("Task created:", end=" ")
-        print(task)
-        self.assertEqual(task.due_date, "", "ERROR: Unable to create task with empty due_date")
-        print("Task successfully created")
+        # Test creating a task with a strinh due date
+        print("Running test to add a task with string date")
+        self.assertRaises(TypeError, self.make_course_with_str_dates)
+        print("Task caused a TypeError correctly")
         print()
 
     def test_create_task_with_invalid_course_id(self):

--- a/test/task_tests.py
+++ b/test/task_tests.py
@@ -10,39 +10,79 @@ class TestTaskMethods(unittest.TestCase):
     def test_create_task(self):
         # Test creating a task
         print("Running test to create a task")
-        task = Task.create_task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
+        task = Task.create_task(
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1
+        )
         print("Task created:", end=" ")
         print(task)
-        self.assertEqual(task.title, "Test Task", "ERROR: task.title was created unsuccessfully")
-        self.assertEqual(task.description, "This is a test task", "ERROR: task.description was created unsuccessfully")
-        self.assertEqual(task.due_date, date.fromisoformat("2023-06-01"), "ERROR: task.due_date was created unsuccessfully")
-        self.assertEqual(task.course_id, 1, "ERROR: task.course_id was created unsuccessfully")
-        self.assertEqual(task.status, "pending", "ERROR: task.status flag was created unsuccessfully")
+        self.assertEqual(
+            task.title, "Test Task", "ERROR: task.title was created unsuccessfully"
+        )
+        self.assertEqual(
+            task.description,
+            "This is a test task",
+            "ERROR: task.description was created unsuccessfully",
+        )
+        self.assertEqual(
+            task.due_date,
+            date.fromisoformat("2023-06-01"),
+            "ERROR: task.due_date was created unsuccessfully",
+        )
+        self.assertEqual(
+            task.course_id, 1, "ERROR: task.course_id was created unsuccessfully"
+        )
+        self.assertEqual(
+            task.status, "pending", "ERROR: task.status flag was created unsuccessfully"
+        )
         print("Task successfully created")
         print()
 
     def test_get_task_details(self):
         # Test getting task details
         print("Running test to get task details")
-        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
+        task = Task(
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1
+        )
         print("Task created:", end=" ")
         print(task)
         details = task.to_dict()
-        self.assertEqual(details["title"], "Test Task", "ERROR: unable to get task.title, or field is incorrect")
-        self.assertEqual(details["description"], "This is a test task", "ERROR: unable to get task.description, or field is incorrect")
+        self.assertEqual(
+            details["title"],
+            "Test Task",
+            "ERROR: unable to get task.title, or field is incorrect",
+        )
+        self.assertEqual(
+            details["description"],
+            "This is a test task",
+            "ERROR: unable to get task.description, or field is incorrect",
+        )
         # date should be a string here, and nowhere else, because the method we are testing
-        # is for preparing the task for JSON saving. JSON cannot save date objects, so we 
+        # is for preparing the task for JSON saving. JSON cannot save date objects, so we
         # make it into an ISO format string.
-        self.assertEqual(details["due_date"], "2023-06-01", "ERROR: unable to get task.due_date, or field is incorrect")
-        self.assertEqual(details["course_id"], 1, "ERROR: unable to get task.course_id, or field is incorrect")
-        self.assertEqual(details["status"], "pending", "ERROR: unable to get task.status flag, or field is incorrect")
+        self.assertEqual(
+            details["due_date"],
+            "2023-06-01",
+            "ERROR: unable to get task.due_date, or field is incorrect",
+        )
+        self.assertEqual(
+            details["course_id"],
+            1,
+            "ERROR: unable to get task.course_id, or field is incorrect",
+        )
+        self.assertEqual(
+            details["status"],
+            "pending",
+            "ERROR: unable to get task.status flag, or field is incorrect",
+        )
         print("Details succefully got")
         print()
 
     def test_update_task(self):
         # Test updating a task
         print("Running test to update a task")
-        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
+        task = Task(
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1
+        )
         print("Task created:", end=" ")
         print(task)
         task.update_task(
@@ -52,44 +92,74 @@ class TestTaskMethods(unittest.TestCase):
         )
         print("Updated Task:", end=" ")
         print(task)
-        self.assertEqual(task.title, "Updated Task", "ERROR: unable to change task.title")
-        self.assertEqual(task.description, "This is an updated task", "ERROR: unable to change task.description")
-        self.assertEqual(task.due_date, date.fromisoformat("2023-07-01"), "ERROR: unable to change task.due_date")
+        self.assertEqual(
+            task.title, "Updated Task", "ERROR: unable to change task.title"
+        )
+        self.assertEqual(
+            task.description,
+            "This is an updated task",
+            "ERROR: unable to change task.description",
+        )
+        self.assertEqual(
+            task.due_date,
+            date.fromisoformat("2023-07-01"),
+            "ERROR: unable to change task.due_date",
+        )
         print("Task successfully updated")
         print()
 
     def test_mark_complete(self):
         # Test marking a task as complete
-        print("Running test to mark a task asa \"complete\"")
-        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
+        print('Running test to mark a task asa "complete"')
+        task = Task(
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1
+        )
         print("Task created:", end=" ")
         print(task)
         task.mark_complete()
         print("Updated Task:", end=" ")
         print(task)
-        self.assertEqual(task.status, "completed", "ERROR: Unable to mark task as \"completed\"")
+        self.assertEqual(
+            task.status, "completed", 'ERROR: Unable to mark task as "completed"'
+        )
         print("Task successfully updated")
         print()
 
     def test_mark_pending(self):
         # Test marking a task as pending
-        print("Running test to mark a task as \"pending\"")
-        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
+        print('Running test to mark a task as "pending"')
+        task = Task(
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1
+        )
         task.mark_complete()
-        print("Task created and pre-marked as \"complete\":", end=" ")
+        print('Task created and pre-marked as "complete":', end=" ")
         print(task)
         task.mark_pending()
         print("Updated Task:", end=" ")
         print(task)
-        self.assertEqual(task.status, "pending", "ERROR: Unable to mark task as \"pending\"")
+        self.assertEqual(
+            task.status, "pending", 'ERROR: Unable to mark task as "pending"'
+        )
         print("Task successfully updated")
         print()
 
     def test_delete_task(self):
         # Test deleting a task from a list
         print("Running test to delete a task from a list")
-        task1 = Task(1, "Test Task 1", "This is a test task 1", date.fromisoformat("2023-06-01"), 1)
-        task2 = Task(2, "Test Task 2", "This is a test task 2", date.fromisoformat("2023-06-02"), 1)
+        task1 = Task(
+            1,
+            "Test Task 1",
+            "This is a test task 1",
+            date.fromisoformat("2023-06-01"),
+            1,
+        )
+        task2 = Task(
+            2,
+            "Test Task 2",
+            "This is a test task 2",
+            date.fromisoformat("2023-06-02"),
+            1,
+        )
         print("Task1 created:", end=" ")
         print(task1)
         print("Task2 created:", end=" ")
@@ -98,28 +168,44 @@ class TestTaskMethods(unittest.TestCase):
         tasks_list = Task.delete_task(tasks_list, 1)
         self.assertNotIn(task1, tasks_list, "ERROR: task1 should not be in the list")
         self.assertIn(task2, tasks_list, "ERROR: task2 should not be missing")
-        self.assertEqual(len(tasks_list), 1, "ERROR: tasks_list should only have 1 object, but " + str(len(tasks_list)) + "was found")
+        self.assertEqual(
+            len(tasks_list),
+            1,
+            "ERROR: tasks_list should only have 1 object, but "
+            + str(len(tasks_list))
+            + "was found",
+        )
         print("Task successfully deleted")
         print()
 
     def test_update_task_with_invalid_field(self):
         # Test updating a task with an invalid field
-        print("Running test to update a task with an invalid field, which should not be possible")
-        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
+        print(
+            "Running test to update a task with an invalid field, which should not be possible"
+        )
+        task = Task(
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1
+        )
         print("Task created:", end=" ")
         print(task)
         task.update_task(invalid_field="Invalid")
-        self.assertFalse(hasattr(task, "invalid_field"), "ERROR: task should not have invalid fields")
+        self.assertFalse(
+            hasattr(task, "invalid_field"), "ERROR: task should not have invalid fields"
+        )
         print("Success! invalid field was not updated, nor does it exist")
         print()
 
     def test_create_task_with_empty_title(self):
         # Test creating a task with an empty title
         print("Running test to create task with an empty title")
-        task = Task.create_task(1, "", "This is a test task", date.fromisoformat("2023-06-01"), 1)
+        task = Task.create_task(
+            1, "", "This is a test task", date.fromisoformat("2023-06-01"), 1
+        )
         print("Task created:", end=" ")
         print(task)
-        self.assertEqual(task.title, "", "ERROR: Unable to create task with empty title")
+        self.assertEqual(
+            task.title, "", "ERROR: Unable to create task with empty title"
+        )
         print("Task successfully created")
         print()
 
@@ -129,7 +215,9 @@ class TestTaskMethods(unittest.TestCase):
         task = Task.create_task(1, "Test Task", "", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
-        self.assertEqual(task.description, "", "ERROR: Unable to create task with empty description")
+        self.assertEqual(
+            task.description, "", "ERROR: Unable to create task with empty description"
+        )
         print("Task successfully created")
         print()
 
@@ -146,54 +234,87 @@ class TestTaskMethods(unittest.TestCase):
     def test_create_task_with_invalid_course_id(self):
         # Test creating a task with an invalid course ID
         print("Running test to create a task with an invalid course_id")
-        task = Task.create_task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), -1)
+        task = Task.create_task(
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), -1
+        )
         print("Task created:", end=" ")
         print(task)
-        self.assertEqual(task.course_id, -1, "ERROR: Unable to create task with invalid course_id")
+        self.assertEqual(
+            task.course_id, -1, "ERROR: Unable to create task with invalid course_id"
+        )
         print("Task successfully created")
         print()
 
     def test_mark_complete_on_already_completed_task(self):
         # Test marking a task as complete when it is already completed
-        print("Running test to mark \"complete\" on a completed task")
+        print('Running test to mark "complete" on a completed task')
         task = Task(
-            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1, status="completed"
+            1,
+            "Test Task",
+            "This is a test task",
+            date.fromisoformat("2023-06-01"),
+            1,
+            status="completed",
         )
         print("Task created:", end=" ")
         print(task)
         task.mark_complete()
         print("Updated Task:", end=" ")
         print(task)
-        self.assertEqual(task.status, "completed", "ERROR: status should be \"completed\", but marked as \"pending\"")
+        self.assertEqual(
+            task.status,
+            "completed",
+            'ERROR: status should be "completed", but marked as "pending"',
+        )
         print("Task successfully updated")
         print()
-        
 
     def test_mark_pending_on_already_pending_task(self):
         # Test marking a task as pending when it is already pending
-        print("Running test to mark \"pending\" on a pending task")
+        print('Running test to mark "pending" on a pending task')
         task = Task(
-            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1, status="pending"
+            1,
+            "Test Task",
+            "This is a test task",
+            date.fromisoformat("2023-06-01"),
+            1,
+            status="pending",
         )
         print("Task created:", end=" ")
         print(task)
         task.mark_pending()
         print("Updated Task:", end=" ")
         print(task)
-        self.assertEqual(task.status, "pending", "ERROR: status should be \"pending\", but marked as \"completed\"")
+        self.assertEqual(
+            task.status,
+            "pending",
+            'ERROR: status should be "pending", but marked as "completed"',
+        )
         print("Task successfully updated")
         print()
 
     def test_delete_non_existent_task(self):
         # Test deleting a non-existent task from a list
         print("Running test to delete a non-existent task from a list")
-        task1 = Task(1, "Test Task 1", "This is a test task 1", date.fromisoformat("2023-06-01"), 1)
+        task1 = Task(
+            1,
+            "Test Task 1",
+            "This is a test task 1",
+            date.fromisoformat("2023-06-01"),
+            1,
+        )
         print("Task created:", end=" ")
         print(task1)
         tasks_list = [task1]
         tasks_list = Task.delete_task(tasks_list, 2)
         self.assertIn(task1, tasks_list, "ERROR: task1 should still be in the list")
-        self.assertEqual(len(tasks_list), 1, "ERROR: tasks_list should only have 1 object, but " + str(len(tasks_list)) + "was found")
+        self.assertEqual(
+            len(tasks_list),
+            1,
+            "ERROR: tasks_list should only have 1 object, but "
+            + str(len(tasks_list))
+            + "was found",
+        )
         print("Success! existing Task task1 was not deleted")
         print()
 

--- a/test/task_tests.py
+++ b/test/task_tests.py
@@ -23,7 +23,7 @@ class TestTaskMethods(unittest.TestCase):
         print(task)
         self.assertEqual(task.title, "Test Task", "ERROR: task.title was created unsuccessfully")
         self.assertEqual(task.description, "This is a test task", "ERROR: task.description was created unsuccessfully")
-        self.assertEqual(task.due_date, "2023-06-01", "ERROR: task.due_date was created unsuccessfully")
+        self.assertEqual(task.due_date, date.fromisoformat("2023-06-01"), "ERROR: task.due_date was created unsuccessfully")
         self.assertEqual(task.course_id, 1, "ERROR: task.course_id was created unsuccessfully")
         self.assertEqual(task.status, "pending", "ERROR: task.status flag was created unsuccessfully")
         print("Task successfully created")
@@ -32,13 +32,13 @@ class TestTaskMethods(unittest.TestCase):
     def test_get_task_details(self):
         # Test getting task details
         print("Running test to get task details")
-        task = Task(1, "Test Task", "This is a test task", "2023-06-01", 1)
+        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
         details = task.get_task_details()
         self.assertEqual(details["title"], "Test Task", "ERROR: unable to get task.title, or field is incorrect")
         self.assertEqual(details["description"], "This is a test task", "ERROR: unable to get task.description, or field is incorrect")
-        self.assertEqual(details["due_date"], "2023-06-01", "ERROR: unable to get task.due_date, or field is incorrect")
+        self.assertEqual(details["due_date"], date.fromisoformat("2023-06-01"), "ERROR: unable to get task.due_date, or field is incorrect")
         self.assertEqual(details["course_id"], 1, "ERROR: unable to get task.course_id, or field is incorrect")
         self.assertEqual(details["status"], "pending", "ERROR: unable to get task.status flag, or field is incorrect")
         print("Details succefully got")
@@ -47,26 +47,26 @@ class TestTaskMethods(unittest.TestCase):
     def test_update_task(self):
         # Test updating a task
         print("Running test to update a task")
-        task = Task(1, "Test Task", "This is a test task", "2023-06-01", 1)
+        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
         task.update_task(
             title="Updated Task",
             description="This is an updated task",
-            due_date="2023-07-01",
+            due_date=date.fromisoformat("2023-07-01"),
         )
         print("Updated Task:", end=" ")
         print(task)
         self.assertEqual(task.title, "Updated Task", "ERROR: unable to change task.title")
         self.assertEqual(task.description, "This is an updated task", "ERROR: unable to change task.description")
-        self.assertEqual(task.due_date, "2023-07-01", "ERROR: unable to change task.due_date")
+        self.assertEqual(task.due_date, date.fromisoformat("2023-07-01"), "ERROR: unable to change task.due_date")
         print("Task successfully updated")
         print()
 
     def test_mark_complete(self):
         # Test marking a task as complete
         print("Running test to mark a task asa \"complete\"")
-        task = Task(1, "Test Task", "This is a test task", "2023-06-01", 1)
+        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
         task.mark_complete()
@@ -79,7 +79,7 @@ class TestTaskMethods(unittest.TestCase):
     def test_mark_pending(self):
         # Test marking a task as pending
         print("Running test to mark a task as \"pending\"")
-        task = Task(1, "Test Task", "This is a test task", "2023-06-01", 1)
+        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
         task.mark_complete()
         print("Task created and pre-marked as \"complete\":", end=" ")
         print(task)
@@ -93,8 +93,8 @@ class TestTaskMethods(unittest.TestCase):
     def test_delete_task(self):
         # Test deleting a task from a list
         print("Running test to delete a task from a list")
-        task1 = Task(1, "Test Task 1", "This is a test task 1", "2023-06-01", 1)
-        task2 = Task(2, "Test Task 2", "This is a test task 2", "2023-06-02", 1)
+        task1 = Task(1, "Test Task 1", "This is a test task 1", date.fromisoformat("2023-06-01"), 1)
+        task2 = Task(2, "Test Task 2", "This is a test task 2", date.fromisoformat("2023-06-02"), 1)
         print("Task1 created:", end=" ")
         print(task1)
         print("Task2 created:", end=" ")
@@ -110,7 +110,7 @@ class TestTaskMethods(unittest.TestCase):
     def test_update_task_with_invalid_field(self):
         # Test updating a task with an invalid field
         print("Running test to update a task with an invalid field, which should not be possible")
-        task = Task(1, "Test Task", "This is a test task", "2023-06-01", 1)
+        task = Task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
         task.update_task(invalid_field="Invalid")
@@ -121,7 +121,7 @@ class TestTaskMethods(unittest.TestCase):
     def test_create_task_with_empty_title(self):
         # Test creating a task with an empty title
         print("Running test to create task with an empty title")
-        task = Task.create_task(1, "", "This is a test task", "2023-06-01", 1)
+        task = Task.create_task(1, "", "This is a test task", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
         self.assertEqual(task.title, "", "ERROR: Unable to create task with empty title")
@@ -131,7 +131,7 @@ class TestTaskMethods(unittest.TestCase):
     def test_create_task_with_empty_description(self):
         # Test creating a task with an empty description
         print("Running test to create a task with an empty description")
-        task = Task.create_task(1, "Test Task", "", "2023-06-01", 1)
+        task = Task.create_task(1, "Test Task", "", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
         self.assertEqual(task.description, "", "ERROR: Unable to create task with empty description")
@@ -151,7 +151,7 @@ class TestTaskMethods(unittest.TestCase):
     def test_create_task_with_invalid_course_id(self):
         # Test creating a task with an invalid course ID
         print("Running test to create a task with an invalid course_id")
-        task = Task.create_task(1, "Test Task", "This is a test task", "2023-06-01", -1)
+        task = Task.create_task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), -1)
         print("Task created:", end=" ")
         print(task)
         self.assertEqual(task.course_id, -1, "ERROR: Unable to create task with invalid course_id")
@@ -162,7 +162,7 @@ class TestTaskMethods(unittest.TestCase):
         # Test marking a task as complete when it is already completed
         print("Running test to mark \"complete\" on a completed task")
         task = Task(
-            1, "Test Task", "This is a test task", "2023-06-01", 1, status="completed"
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1, status="completed"
         )
         print("Task created:", end=" ")
         print(task)
@@ -178,7 +178,7 @@ class TestTaskMethods(unittest.TestCase):
         # Test marking a task as pending when it is already pending
         print("Running test to mark \"pending\" on a pending task")
         task = Task(
-            1, "Test Task", "This is a test task", "2023-06-01", 1, status="pending"
+            1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1, status="pending"
         )
         print("Task created:", end=" ")
         print(task)
@@ -192,7 +192,7 @@ class TestTaskMethods(unittest.TestCase):
     def test_delete_non_existent_task(self):
         # Test deleting a non-existent task from a list
         print("Running test to delete a non-existent task from a list")
-        task1 = Task(1, "Test Task 1", "This is a test task 1", "2023-06-01", 1)
+        task1 = Task(1, "Test Task 1", "This is a test task 1", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task1)
         tasks_list = [task1]
@@ -210,9 +210,9 @@ class TestSortingMethods(unittest.TestCase):
     def test_sort_tasks_by_due_date(self, mock_file, mock_save_tasks):
         # Test sorting tasks by due date
         print("Running test to sort tasks by due date")
-        task1 = Task(1, "Task A", "This is Task A", "2023-06-01", 1)
-        task2 = Task(2, "Task B", "This is Task B", "2023-06-11", 1)
-        task3 = Task(3, "Task C", "This is Task C", "2023-06-05", 1)
+        task1 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
+        task2 = Task(2, "Task B", "This is Task B", date.fromisoformat("2023-06-11"), 1)
+        task3 = Task(3, "Task C", "This is Task C", date.fromisoformat("2023-06-05"), 1)
         mock_tasks = [task1.__dict__, task2.__dict__, task3.__dict__]
 
         # Mock file reading with JSON data
@@ -232,9 +232,9 @@ class TestSortingMethods(unittest.TestCase):
     def test_sort_tasks_by_course_id(self, mock_file, mock_save_tasks):
         # Test sorting tasks by course id
         print("Running test to sort tasks by course id")
-        task1 = Task(1, "Task A", "This is Task A", "2023-06-01", 4)
-        task2 = Task(2, "Task B", "This is Task B", "2023-06-11", 8)
-        task3 = Task(3, "Task C", "This is Task C", "2023-06-05", 2)
+        task1 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 4)
+        task2 = Task(2, "Task B", "This is Task B", date.fromisoformat("2023-06-11"), 8)
+        task3 = Task(3, "Task C", "This is Task C", date.fromisoformat("2023-06-05"), 2)
         mock_tasks = [task1.__dict__, task2.__dict__, task3.__dict__]
 
         # Mock file reading with JSON data
@@ -253,9 +253,9 @@ class TestSortingMethods(unittest.TestCase):
     @patch("src.main.open", new_callable=mock_open)
     def test_sort_tasks_by_due_date_all_same(self, mock_file, mock_save_tasks):
         print("Running test to sort tasks by due date, but all have the same due date")
-        task1 = Task(1, "Task A", "This is Task A", "2023-06-01", 1)
-        task2 = Task(1, "Task A", "This is Task A", "2023-06-01", 2)
-        task3 = Task(1, "Task A", "This is Task A", "2023-06-01", 3)
+        task1 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
+        task2 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 2)
+        task3 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 3)
         mock_tasks = [task1.__dict__, task2.__dict__, task3.__dict__]
 
         # Mock file reading with JSON data
@@ -274,9 +274,9 @@ class TestSortingMethods(unittest.TestCase):
     @patch("src.main.open", new_callable=mock_open)
     def test_sort_tasks_by_course_id_all_same(self, mock_file, mock_save_tasks):
         print("Running test to sort tasks by course id, but all have the same course id")
-        task1 = Task(1, "Task A", "This is Task A", "2023-06-01", 1)
-        task2 = Task(2, "Task A", "This is Task A", "2023-06-01", 1)
-        task3 = Task(3, "Task A", "This is Task A", "2023-06-01", 1)
+        task1 = Task(1, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
+        task2 = Task(2, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
+        task3 = Task(3, "Task A", "This is Task A", date.fromisoformat("2023-06-01"), 1)
         mock_tasks = [task1.__dict__, task2.__dict__, task3.__dict__]
 
         # Mock file reading with JSON data

--- a/test/task_tests.py
+++ b/test/task_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, mock_open
 import json
+from datetime import date
 from src.task import Task
 from src.main import (
     load_tasks,
@@ -17,7 +18,7 @@ class TestTaskMethods(unittest.TestCase):
     def test_create_task(self):
         # Test creating a task
         print("Running test to create a task")
-        task = Task.create_task(1, "Test Task", "This is a test task", "2023-06-01", 1)
+        task = Task.create_task(1, "Test Task", "This is a test task", date.fromisoformat("2023-06-01"), 1)
         print("Task created:", end=" ")
         print(task)
         self.assertEqual(task.title, "Test Task", "ERROR: task.title was created unsuccessfully")


### PR DESCRIPTION
I have replaced every usage of date strings with an actual date object. We get validation and comparisons for free with this. The date objects are saved out to JSON as ISOformat strings. When parsing the JSON, they are converted back into date objects.

The error handling isn't quite working, in that no popup appears indicating an invalid date to the user. I can't figure out why that is, because it is raising a `ValueError` in exactly the same place that the empty courses are raising a ValueError, but it isn't getting caught. If someone who wrote the error handling code could help me debug this, I'd be grateful.

Thanks to Chun for assisting with the coding on this PR.