### PR TITLE
Filter have been fixed

### DIFF
--- a/src/course.py
+++ b/src/course.py
@@ -69,10 +69,6 @@ class Course:
             + self.end_date.strftime("%Y/%m/%d")
             + "}"
         )
-    
-    def __getitem__():
-        """Make this object subscriptable"""
-        pass
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert Course instance to dictionary for JSON serialization."""

--- a/src/course.py
+++ b/src/course.py
@@ -69,6 +69,10 @@ class Course:
             + self.end_date.strftime("%Y/%m/%d")
             + "}"
         )
+    
+    def __getitem__():
+        """Make this object subscriptable"""
+        pass
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert Course instance to dictionary for JSON serialization."""

--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -164,17 +164,17 @@ class TaskManagerGUI:
         filtered_tasks = [
             task
             for task in self.all_tasks
-            if course == "All Courses" or task[2] == course
+            if course == "All Courses" or task.course_id == course
         ]
 
         # Display filtered tasks
         for task in filtered_tasks:
             task_item = TaskItem(
                 self.task_container,
-                task[0],
-                task[1],
-                task[2],
-                task[3],
+                task.title,
+                task.description,
+                task.course_id,
+                task.due_date,
                 delete_callback=self.delete_task,
                 edit_callback=self.edit_task,
             )

--- a/src/task.py
+++ b/src/task.py
@@ -54,10 +54,6 @@ class Task:
             + self.status
             + "}"
         )
-
-    def __getitem__():
-        """Make this object subscriptable"""
-        pass
     
     @staticmethod
     def create_task(

--- a/src/task.py
+++ b/src/task.py
@@ -55,6 +55,10 @@ class Task:
             + "}"
         )
 
+    def __getitem__():
+        """Make this object subscriptable"""
+        pass
+    
     @staticmethod
     def create_task(
         task_id: int, title: str, description: str, due_date: date, course_id: int


### PR DESCRIPTION
The issue is the code attempting to access task attributes by list, so it throws a non-subscriptable error. The fix (provided by GitHub Copilot) is just to reference attributes from task.py directly, no implementation of __getitem__.

Example:
task[1] to task.description