### PR TITLE
File import

### DIFF
--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -511,6 +511,9 @@ class TaskManagerGUI:
         file = filedialog.askopenfile(title="Select file to import")
         if file is None:
             return # user canceled the dialog
+        if not file.name.endswith(".json"):
+            messagebox.showerror("Error", "File is not a JSON file.")
+            return
         try:
             Task.load_tasks_from_file(file)
             messagebox.showinfo("Success", "Tasks imported successfully")

--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -363,6 +363,11 @@ class TaskManagerGUI:
         )
         export_tasks_button.pack(side=tk.RIGHT, padx=10, pady=10)
 
+        import_tasks_button = CustomButton(
+            self.nav_bar, text="Import Tasks", command=self.import_tasks
+        )
+        import_tasks_button.pack(side=tk.RIGHT, padx=10, pady=10)
+
         # Create a container for tasks below the nav bar
         self.task_container = tk.Frame(self.root, bg="#E6E6E6")
         self.task_container.pack(fill="both", expand=True, padx=20, pady=20)

--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -501,6 +501,18 @@ class TaskManagerGUI:
         except ValueError as e:
             messagebox.showerror("Error", str(e))
 
+    def import_tasks(self):
+        """Import tasks from a user-selected JSON file."""
+        file = filedialog.askopenfile(title="Select file to import")
+        if file is None:
+            return # user canceled the dialog
+        try:
+            Task.load_tasks_from_file(file)
+            messagebox.showinfo("Success", "Tasks imported successfully")
+        except ValueError as e:
+            messagebox.showerror("Error", str(e))
+
+
 
 def main():
     root = tk.Tk()

--- a/src/task.py
+++ b/src/task.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import List, Dict, Any
+from typing import List, Dict, Any, IO
 from datetime import date
 
 TASK_FILE = "tasks.json"
@@ -124,6 +124,15 @@ class Task:
         except FileNotFoundError:
             return []
 
+    @classmethod
+    def load_tasks_from_file(cls, file: IO) -> List["Task"]:
+        """Load tasks from specified JSON file"""
+        try:
+            tasks_data = json.load(file)
+            return [cls.from_dict(task) for task in tasks_data]
+        except FileNotFoundError:
+            return []
+
     @staticmethod
     def save_tasks(tasks: List["Task"]) -> None:
         """Save tasks to JSON file"""
@@ -145,22 +154,25 @@ class Task:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Task":
         """Create Task instance from dictionary"""
-        # Convert due_date string to date object
-        due_date_str = data["due_date"]
-        if isinstance(due_date_str, str):
-            due_date = date.fromisoformat(due_date_str)
-        else:
-            due_date = due_date_str
-
-        core_attrs = cls(
-            task_id=data["task_id"],
-            title=data["title"],
-            description=data["description"],
-            due_date=due_date,
-            course_id=data["course_id"],
-            status=data["status"],
-        )
-        return core_attrs
+        try:
+            # Convert due_date string to date object
+            due_date_str = data["due_date"]
+            if isinstance(due_date_str, str):
+                due_date = date.fromisoformat(due_date_str)
+            else:
+                due_date = due_date_str
+    
+            core_attrs = cls(
+                task_id=data["task_id"],
+                title=data["title"],
+                description=data["description"],
+                due_date=due_date,
+                course_id=data["course_id"],
+                status=data["status"],
+            )
+            return core_attrs
+        except:
+            raise ValueError("JSON file has unsupported or missing attributes")
 
     @staticmethod
     def export_tasks(tasks: List["Task"], directory: str) -> None:


### PR DESCRIPTION
Add a button to import from a file, patterned after the export functionality. Correctly gives an error box if users attempt to use a JSON file that isn't formatted correctly, or if users attempt to use a non-JSON file.

If users try to import a file with mismatched courses.... they're on their own. We can maybe put that in the product backlog as something we would fix with a more comprehensive export-import system if we were taking this product to market. 